### PR TITLE
Fix DAG definition retrieval

### DIFF
--- a/src/maestro/server/internals/status_manager.py
+++ b/src/maestro/server/internals/status_manager.py
@@ -349,7 +349,17 @@ class StatusManager:
     def get_dag_definition(self, dag_id: str) -> Optional[Dict]:
         with self.Session() as session:
             dag = session.query(DagORM).filter_by(id=dag_id).first()
-            return dag.dag_filepath if dag else None
+            if not dag:
+                return None
+
+            if dag.definition is None:
+                return None
+
+            try:
+                return json.loads(dag.definition)
+            except (TypeError, json.JSONDecodeError):
+                # If the stored definition is not valid JSON, fall back to returning the raw value
+                return dag.definition
 
     def delete_dag(self, dag_id: str) -> int:
         with self.Session.begin() as session:

--- a/tests/test_status_manager.py
+++ b/tests/test_status_manager.py
@@ -312,3 +312,19 @@ def test_task_status_with_timestamps(status_manager):
         assert task["completed_at"] is not None
         assert task["status"] == "completed"
 
+
+def test_get_dag_definition_returns_saved_definition(status_manager):
+    class DummyDag:
+        dag_id = "dummy_dag"
+
+        def to_dict(self):
+            return {"dag_id": self.dag_id, "tasks": {}}
+
+    with status_manager as sm:
+        dag = DummyDag()
+        sm.save_dag_definition(dag)
+
+        stored_definition = sm.get_dag_definition(dag.dag_id)
+
+    assert stored_definition == dag.to_dict()
+


### PR DESCRIPTION
## Summary
- return the stored DAG definition JSON from `StatusManager.get_dag_definition`
- add a regression test that ensures saved DAG definitions are retrieved as dictionaries

## Testing
- PYTHONPATH=src pytest tests/test_status_manager.py --override-ini addopts="" -k get_dag_definition *(fails: missing dependency `rich` in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e10f067b8883328516868791191ff7