### PR TITLE
Force merge feature/orm-refactor into main

### DIFF
--- a/src/maestro/__init__.py
+++ b/src/maestro/__init__.py
@@ -1,0 +1,9 @@
+"""Expose top-level Maestro packages for compatibility."""
+
+from . import client, server, shared
+
+__all__ = [
+    "client",
+    "server",
+    "shared",
+]

--- a/src/maestro/server/__init__.py
+++ b/src/maestro/server/__init__.py
@@ -1,1 +1,19 @@
-# Maestro Server Package
+"""Expose server subpackages for importlib-based lookups.
+
+The test-suite performs patching using dotted import paths such as
+``maestro.server.internals.status_manager.StatusManager``.  The
+``pkgutil.resolve_name`` helper that backs :func:`unittest.mock.patch`
+expects the ``internals`` attribute to be available directly on the
+``maestro.server`` package.  Explicitly importing the subpackages makes the
+attributes available so that the ORM refactor package layout continues to
+work with the existing tests.
+"""
+
+from . import api, internals, services, tasks
+
+__all__ = [
+    "api",
+    "internals",
+    "services",
+    "tasks",
+]


### PR DESCRIPTION
## Summary
- merge the `feature/orm-refactor` branch into `main`, bringing the reorganised ORM-backed status manager, server API routes, and shared DAG/task models
- expose the new package layout from `maestro` and `maestro.server` so existing dotted-path imports keep working during tests

## Testing
- PYTHONPATH=src pytest tests/test_dag.py *(fails: ModuleNotFoundError: No module named 'ansible_runner')*


------
https://chatgpt.com/codex/tasks/task_e_68e12087992883328cfe5b2df41d71d6